### PR TITLE
[Bug] Hide sharing links on `/about` and `/contact`

### DIFF
--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,6 +1,7 @@
 ---
 title: About Me
 layout: simple
+sharingLinks: false
 ---
 
 What started with "*computers are interesting*", ended up with building custom servers for my Home Lab, tinkering with Raspberry Pi clusters, automating deployments, and being the sysadmin of my personal "datacenter".

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,6 +1,7 @@
 ---
-title: "Contact"
+title: Contact
 layout: simple
+sharingLinks: false
 ---
 
 {{< netlify_contact_form >}}


### PR DESCRIPTION
Fixes #59 